### PR TITLE
Modified API Manager Metric Diag Settings

### DIFF
--- a/policy-definitions/resource-diagnostics-settings/log-analytics/azurepolicy.apiMgmt-la.json
+++ b/policy-definitions/resource-diagnostics-settings/log-analytics/azurepolicy.apiMgmt-la.json
@@ -104,40 +104,9 @@
                       "logAnalyticsDestinationType": "[variables('logAnalyticsDestinationType')]",
                       "metrics": [
                         {
-                          "category": "Gateway Requests",
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "days": 0,
-                            "enabled": false
-                          },
-                          "timeGrain": null
-                        },
-                        {
-                          "category": "Capacity",
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "days": 0,
-                            "enabled": false
-                          },
-                          "timeGrain": null
-                        },
-                        {
-                          "category": "EventHub Events",
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "days": 0,
-                            "enabled": false
-                          },
-                          "timeGrain": null
-                        },
-                        {
-                          "category": "Network Status",
-                          "enabled": true,
-                          "retentionPolicy": {
-                            "days": 0,
-                            "enabled": false
-                          },
-                          "timeGrain": null
+                            "category": "AllMetrics",
+                            "timeGrain": null,
+                            "enabled": true
                         }
                       ],
                       "logs": [


### PR DESCRIPTION
API Manager diagnostic settings has changed to only allow "All Metrics". Changed the ARM template section to accommodate the diagnostics change.